### PR TITLE
Park Vehicle option from qb-radialmenu.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -864,3 +864,12 @@ CreateThread(function()
         end
     end
 end)
+
+AddEventHandler('onResourceStop', function(resource)
+    if resource == GetCurrentResourceName() then
+        if MenuItemId ~= nil then
+            exports['qb-radialmenu']:RemoveOption(MenuItemId)
+            MenuItemId = nil
+        end
+    end
+end)


### PR DESCRIPTION
This will remove the Park Vehicle option from qb-radialmenu when the resource (qb-garages) stops. I noticed it would duplicated onto the radialmenu if you restarted qb-garages and then you'd have to restart qb-radialmenu to remove it. Simple QOL